### PR TITLE
Set input to checked semantically, updated style

### DIFF
--- a/Junior/Pricing-Component-With-Toggle/index.html
+++ b/Junior/Pricing-Component-With-Toggle/index.html
@@ -32,7 +32,13 @@
         <form>
           <label for="plan" class="pricing__plan">
             <span>Annually</span>
-            <input type="checkbox" id="plan" name="Plan" class="plan__input" />
+            <input
+              type="checkbox"
+              id="plan"
+              name="Plan"
+              class="plan__input"
+              checked
+            />
             <span class="plan__toggle" tabindex="0"></span>
             <span>Monthly</span>
           </label>

--- a/Junior/Pricing-Component-With-Toggle/style.css
+++ b/Junior/Pricing-Component-With-Toggle/style.css
@@ -195,14 +195,14 @@ main {
   content: "";
   z-index: 2;
   top: 0.4rem;
-  left: 2.8rem;
+  left: 0.4rem;
   width: 2.4rem;
   height: 2.4rem;
   border-radius: 50%;
 }
 
 .plan__input:checked ~ .plan__toggle::before {
-  left: 0.4rem;
+  left: 2.8rem;
 }
 
 /* ~CARDS~ */


### PR DESCRIPTION
This version has the `checked` state written in the html for the `input`. However, the `monthly` class is still added to the `card__price` to make sure the toggle is accurately depicting the prices.