### PR TITLE
Translating the checkbox behind the toggle

### DIFF
--- a/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/anims.css
+++ b/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/anims.css
@@ -9,8 +9,8 @@
     height: 8rem;
     width: 8rem;
     opacity: 0;
-    bottom: -2.7rem;
-    left: -1.25rem;
+    bottom: -3.3rem;
+    left: -4rem;
   }
 }
 

--- a/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/queries.css
+++ b/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/queries.css
@@ -75,7 +75,7 @@
   }
 
   .header__darkmode {
-    gap: 1.4rem;
+    gap: 1rem;
   }
 
   .dashboard__top,

--- a/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/style.css
+++ b/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/style.css
@@ -107,6 +107,8 @@ header {
 .darkmode__input {
   position: relative;
   animation: 1s hideRipple forwards;
+
+  /* Fixes safari bug -- checkbox still showing desipite width set to 0 */
   transform: translateX(3rem);
 }
 

--- a/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/style.css
+++ b/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/style.css
@@ -23,10 +23,7 @@ label {
 }
 
 input {
-  height: 0;
   width: 0;
-  transform: scale(0);
-  /* visibility: hidden; */
 }
 
 body {

--- a/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/style.css
+++ b/Junior/Social-Media-Dashboard-With-Theme-Switcher/css/style.css
@@ -107,13 +107,14 @@ header {
 .darkmode__input {
   position: relative;
   animation: 1s hideRipple forwards;
+  transform: translateX(3rem);
 }
 
 .darkmode__input:checked::after,
 .darkmode__input:not(:checked)::before {
   position: absolute;
-  bottom: -1.3rem;
-  left: 0.3rem;
+  bottom: -2.2rem;
+  left: -2.6rem;
   border-radius: 50%;
   content: "";
   background: var(--toggledark);


### PR DESCRIPTION
Since I do need the input visible for the ripple effect, I simply positioned the checkbox behind the toggle on Safari.
This only required changing a few lines of code. I removed the height because doing so aligned the checkbox directly to the left of the toggle. This means I just have to translate it on the x-axis.